### PR TITLE
Reduce memory usage of preprocessing logic

### DIFF
--- a/src/annbatch/io.py
+++ b/src/annbatch/io.py
@@ -172,8 +172,11 @@ def _compute_blockwise(x: DaskArray) -> sp.spmatrix:
 
 
 def _persist_adata_in_memory(adata: ad.AnnData) -> ad.AnnData:
-    if isinstance(adata.X, DaskArray) and isinstance(adata.X._meta, sp.csr_matrix | sp.csr_array):
-        adata.X = _compute_blockwise(adata.X)
+    if isinstance(adata.X, DaskArray):
+        if isinstance(adata.X._meta, sp.csr_matrix | sp.csr_array):
+            adata.X = _compute_blockwise(adata.X)
+        else:
+            adata.X = adata.X.compute()
     if isinstance(adata.obs, Dataset2D):
         adata.obs = adata.obs.to_memory()
     if isinstance(adata.var, Dataset2D):
@@ -181,8 +184,11 @@ def _persist_adata_in_memory(adata: ad.AnnData) -> ad.AnnData:
 
     if adata.raw is not None:
         adata_raw = adata.raw.to_adata()
-        if isinstance(adata_raw.X, DaskArray) and isinstance(adata_raw.X._meta, sp.csr_array | sp.csr_matrix):
-            adata_raw.X = _compute_blockwise(adata_raw.X)
+        if isinstance(adata_raw.X, DaskArray):
+            if isinstance(adata_raw.X._meta, sp.csr_array | sp.csr_matrix):
+                adata_raw.X = _compute_blockwise(adata_raw.X)
+            else:
+                adata_raw.X = adata_raw.X.compute()
         if isinstance(adata_raw.var, Dataset2D):
             adata_raw.var = adata_raw.var.to_memory()
         if isinstance(adata_raw.obs, Dataset2D):
@@ -193,11 +199,17 @@ def _persist_adata_in_memory(adata: ad.AnnData) -> ad.AnnData:
     for k, elem in adata.obsm.items():
         # TODO: handle `Dataset2D` in `obsm` and `varm` that are
         if isinstance(elem, DaskArray):
-            adata.obsm[k] = elem.compute()
+            if isinstance(elem, sp.csr_matrix | sp.csr_array):
+                adata.obsm[k] = _compute_blockwise(elem)
+            else:
+                adata.obsm[k] = elem.compute()
 
     for k, elem in adata.layers.items():
         if isinstance(elem, DaskArray):
-            adata.layers[k] = elem.compute()
+            if isinstance(elem, sp.csr_matrix | sp.csr_array):
+                adata.layers[k] = _compute_blockwise(elem)
+            else:
+                adata.layers[k] = elem.compute()
 
     return adata
 


### PR DESCRIPTION
I've updated the preprocessing code to reduce the memory footprint. On top of this, the preprocessing also got a bit faster.

```
   293    581.4 MiB      0.0 MiB           1       Path(output_path).mkdir(parents=True, exist_ok=True)
   294    581.4 MiB      0.0 MiB           1       ad.settings.zarr_write_format = 3
   295   1069.4 MiB    488.1 MiB           1       _check_for_mismatched_keys(adata_paths)
   296   4622.3 MiB   3552.9 MiB           1       adata_concat = _lazy_load_anndatas(adata_paths, load_adata=load_adata)
   297   4110.3 MiB   -512.0 MiB           1       adata_concat.obs_names_make_unique()
   298   4110.3 MiB      0.0 MiB           1       chunks = _create_chunks_for_shuffling(adata_concat, n_obs_per_dataset, shuffle=shuffle)
   299                                         
   300   4110.3 MiB      0.0 MiB           1       if var_subset is None:
   301   4110.3 MiB      0.0 MiB           1           var_subset = adata_concat.var_names
   302                                         
   303   4110.3 MiB      0.0 MiB           1       for i, chunk in enumerate(tqdm(chunks)):
   304   4110.3 MiB      0.0 MiB           1           var_mask = adata_concat.var_names.isin(var_subset)
   305                                                 # np.sort: It's more efficient to access elements sequentially from dask arrays
   306                                                 # The data will be shuffled later on, we just want the elements at this point
   307   4180.2 MiB     69.9 MiB           1           adata_chunk = adata_concat[np.sort(chunk), :][:, var_mask].copy()
   308  64430.5 MiB  60250.3 MiB           1           adata_chunk = _persist_adata_in_memory(adata_chunk)
   309  64430.5 MiB      0.0 MiB           1           if shuffle:
   310                                                     # shuffle adata in memory to break up individual chunks
   311  64430.5 MiB      0.0 MiB           1               idxs = np.random.default_rng().permutation(np.arange(len(adata_chunk)))
   312  64430.5 MiB      0.0 MiB           1               adata_chunk = adata_chunk[idxs]
   313                                                 # convert to dense format before writing to disk
   314  64430.5 MiB      0.0 MiB           1           if should_denseify:
   315                                                     # Need to convert back to dask array to avoid memory issues when converting large sparse matrices to dense
   316                                                     adata_chunk = adata_chunk.copy()
   317                                                     adata_chunk.X = da.from_array(
   318                                                         adata_chunk.X, chunks=(zarr_dense_chunk_size, -1), meta=adata_chunk.X
   319                                                     ).map_blocks(lambda xx: xx.toarray(), dtype=adata_chunk.X.dtype)
   320                                         
   321  64430.5 MiB      0.0 MiB           1           if output_format == "zarr":
   322  64430.5 MiB      0.0 MiB           1               f = zarr.open_group(Path(output_path) / f"{DATASET_PREFIX}_{i}.zarr", mode="w")
   323  64559.8 MiB    129.3 MiB           2               write_sharded(
   324  64430.5 MiB      0.0 MiB           1                   f,
   325  64430.5 MiB      0.0 MiB           1                   adata_chunk,
   326  64430.5 MiB      0.0 MiB           1                   sparse_chunk_size=zarr_sparse_chunk_size,
   327  64430.5 MiB      0.0 MiB           1                   sparse_shard_size=zarr_sparse_shard_size,
   328  64430.5 MiB      0.0 MiB           1                   dense_chunk_size=zarr_dense_chunk_size,
   329  64430.5 MiB      0.0 MiB           1                   dense_shard_size=zarr_dense_shard_size,
   330  64430.5 MiB      0.0 MiB           1                   compressors=zarr_compressor,
   331                                                     )
   332                                                 elif output_format == "h5ad":
   333                                                     adata_chunk.write_h5ad(Path(output_path) / f"{DATASET_PREFIX}_{i}.h5ad", compression=h5ad_compressor)
   334                                                 else:
   335                                                     raise ValueError(f"Unrecognized output_format: {output_format}. Only 'zarr' and 'h5ad' are supported.")
```