### PR TITLE
fix: `obs` and `var` into memory by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning][].
 
 - `ZarrSparseDataset` and `ZarrDenseDataset` have been conslidated into {class}`annbatch.Loader`
 - `create_anndata_collection` and `add_to_collection` have been moved into the {meth}`annbatch.DatasetCollection.add_adatas` method
-- Default reading of input data is now fully lazy in {meth}`annbatch.DatasetCollection.add_adatas`, and therefore the shuffle process may now be slower although have better memory properties.  Use `load_adata` argument in {meth}`annbatch.DatasetCollection.add_adatas` to customize this behavior.
+- Default reading of input data is fully lazy except `obs` and `var` in {meth}`annbatch.DatasetCollection.add_adatas`.  Use `load_adata` argument in {meth}`annbatch.DatasetCollection.add_adatas` to customize this behavior.
 
 ### Changed
 

--- a/tests/test_preshuffle.py
+++ b/tests/test_preshuffle.py
@@ -172,9 +172,9 @@ def test_store_creation_default(
 
 
 @pytest.mark.parametrize("shuffle", [pytest.param(True, id="shuffle"), pytest.param(False, id="no_shuffle")])
+@pytest.mark.parametrize("load_adata_lazy", [True, False], ids=["lazy", "default"])
 def test_store_creation(
-    adata_with_h5_path_different_var_space: tuple[ad.AnnData, Path],
-    shuffle: bool,
+    adata_with_h5_path_different_var_space: tuple[ad.AnnData, Path], shuffle: bool, load_adata_lazy: bool
 ):
     var_subset = [f"gene_{i}" for i in range(100)]
     h5_files = sorted(adata_with_h5_path_different_var_space[1].iterdir())
@@ -189,6 +189,7 @@ def test_store_creation(
         n_obs_per_dataset=50,
         shuffle_chunk_size=10,
         shuffle=shuffle,
+        **({"load_adata": ad.experimental.read_lazy} if load_adata_lazy else {}),
     )
     assert not DatasetCollection(output_path).is_empty
     assert V1_ENCODING.items() <= zarr.open(output_path).attrs.items()

--- a/tests/test_preshuffle.py
+++ b/tests/test_preshuffle.py
@@ -178,7 +178,9 @@ def test_store_creation(
 ):
     var_subset = [f"gene_{i}" for i in range(100)]
     h5_files = sorted(adata_with_h5_path_different_var_space[1].iterdir())
-    output_path = adata_with_h5_path_different_var_space[1].parent / f"zarr_store_creation_test_{shuffle}.zarr"
+    output_path = (
+        adata_with_h5_path_different_var_space[1].parent / f"zarr_store_creation_test_{shuffle}_{load_adata_lazy}.zarr"
+    )
     collection = DatasetCollection(output_path).add_adatas(
         [adata_with_h5_path_different_var_space[1] / f for f in h5_files if str(f).endswith(".h5ad")],
         var_subset=var_subset,


### PR DESCRIPTION
I didn't see much performance improvement with `hdf5` files.  Until I understand this further, I think this is a better way forward.