### PR TITLE
perf: new `obs` handling default for shuffling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.0.4]
+
+- Load into memory nullables/categoricals from `obs` by default when shuffling (i.e., no custom `load_adata` argument to {meth}`annbatch.Datasetcollection.add_adatas`)
+
 ## [0.0.3]
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.0.4]
 
-- Load into memory nullables/categoricals from `obs` by default when shuffling (i.e., no custom `load_adata` argument to {meth}`annbatch.Datasetcollection.add_adatas`)
+- Load into memory nullables/categoricals from `obs` by default when shuffling (i.e., no custom `load_adata` argument to {meth}`annbatch.DatasetCollection.add_adatas`)
 
 ## [0.0.3]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,7 @@ intersphinx_mapping = {
     "cupy": ("https://docs.cupy.dev/en/stable/", None),
     "zarrs": ("https://zarrs-python.readthedocs.io/en/latest/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
+    "h5py": ("https://docs.h5py.org/en/latest", None),
 }
 
 # List of patterns, relative to source directory, that match files and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,4 +139,5 @@ nitpick_ignore = [
 qualname_overrides = {
     "zarr.core.array.Array": "zarr.Array",
     "zarr.core.group.Group": "zarr.Group",
+    "h5py._hl.group.Group": "h5py.Group",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "annbatch"
-version = "0.0.3"
+version = "0.0.4"
 description = "A minibatch loader for AnnData stores"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/annbatch/io.py
+++ b/src/annbatch/io.py
@@ -36,7 +36,7 @@ V1_ENCODING = {"encoding-type": "annbatch-preshuffled", "encoding-version": "0.1
 def _default_load_adata[T: zarr.Group | h5py.Group | PathLike[str] | str](x: T) -> ad.AnnData:
     adata = ad.experimental.read_lazy(x, load_annotation_index=False)
     if not isinstance(x, zarr.Group | h5py.Group):
-        group = h5py.File(adata.file.filename) if adata.file.filename is not None else zarr.open(x)
+        group = h5py.File(adata.file.filename, mode="r") if adata.file.filename is not None else zarr.open(x, mode="r")
     else:
         group = x
     # -1 indicates that all of each `obs` column should just be loaded, but this is probably fine since it goes column by column and discards.

--- a/src/annbatch/io.py
+++ b/src/annbatch/io.py
@@ -44,11 +44,11 @@ def _default_load_adata[T: zarr.Group | h5py.Group | PathLike[str] | str](x: T) 
     # https://github.com/scverse/anndata/pull/2307
     for attr in ["obs", "var"]:
         if len(getattr(adata, attr).columns) > 0:
-            setattr(adata, attr, ad.experimental.read_elem_lazy(group[attr], chunks=(-1,)))
+            setattr(adata, attr, ad.experimental.read_elem_lazy(group[attr], chunks=(-1,), use_range_index=True))
             for col in getattr(adata, attr).columns:
                 # Nullables / categoricals have bad perforamnce characteristics when concatenating using dask
-                if pd.api.types.is_extension_array_dtype(adata.obs[col].dtype):
-                    adata.obs[col] = adata.obs[col].data
+                if pd.api.types.is_extension_array_dtype(getattr(adata, attr)[col].dtype):
+                    setattr(getattr(adata, attr), col, getattr(adata, attr)[col].data)
     return adata
 
 

--- a/src/annbatch/io.py
+++ b/src/annbatch/io.py
@@ -39,8 +39,8 @@ def _default_load_adata[T: zarr.Group | h5py.Group | PathLike[str] | str](x: T) 
         group = h5py.File(adata.file.filename) if adata.file.filename is not None else zarr.open(x)
     else:
         group = x
-    # -1 indicates that all of `obs` should just be loaded, but this is probably fine going column by column.
-    # Only one column at a time will be loaded anyway so we will hopefully pick up the benefit of loading into memory by the cache without having memory pressure.
+    # -1 indicates that all of each `obs` column should just be loaded, but this is probably fine since it goes column by column and discards.
+    # Only one column at a time will be loaded so we will hopefully pick up the benefit of loading into memory by the cache without having memory pressure.
     adata.obs = ad.experimental.read_elem_lazy(group["obs"], chunks=(-1,))
     for col in adata.obs.columns:
         # Nullables / categoricals have bad perforamnce characteristics when concatenating using dask

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def adata_with_h5_path_different_var_space(
     adatas = []
     for i, (m, n) in enumerate(zip(n_cells, n_features, strict=True)):
         var_idx = [f"gene_{gene}" for gene in range(n // 2)] + [f"gene_{gene}_{i}" for gene in range(n // 2, n)]
-        obs_idx = np.arange(m).astype(str) + f"-{i}"
+        obs_idx = [f"cell_{j}" for j in np.arange(m).astype(str) + f"-{i}"]
         adata = ad.AnnData(
             X=sparse_random(m, n, density=0.1, format="csr", dtype="f4"),
             obs=pd.DataFrame(


### PR DESCRIPTION
1. Big chunks are better for dask 
2. Reading the categoricals into memory means we don't have to go through dask for concatenation at a memory penalty (negligible from my testing)

From what I see, this should be about a ~40% reduction in shuffling time