### PR TITLE
fix: actually set the column to the in-memory data when shuffling by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.0.5]
+
+- Fix bug with bringing the nullable/categorical columns into memory by default
+
 ## [0.0.4]
 
 - Load into memory nullables/categoricals from `obs` by default when shuffling (i.e., no custom `load_adata` argument to {meth}`annbatch.DatasetCollection.add_adatas`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "annbatch"
-version = "0.0.4"
+version = "0.0.5"
 description = "A minibatch loader for AnnData stores"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/annbatch/io.py
+++ b/src/annbatch/io.py
@@ -52,7 +52,7 @@ def _default_load_adata[T: zarr.Group | h5py.Group | PathLike[str] | str](x: T) 
             for col in getattr(adata, attr).columns:
                 # Nullables / categoricals have bad perforamnce characteristics when concatenating using dask
                 if pd.api.types.is_extension_array_dtype(getattr(adata, attr)[col].dtype):
-                    getattr(adata, attr)[col] = getattr(adata, attr)[col].data)
+                    getattr(adata, attr)[col] = getattr(adata, attr)[col].data
     return adata
 
 

--- a/src/annbatch/io.py
+++ b/src/annbatch/io.py
@@ -52,7 +52,7 @@ def _default_load_adata[T: zarr.Group | h5py.Group | PathLike[str] | str](x: T) 
             for col in getattr(adata, attr).columns:
                 # Nullables / categoricals have bad perforamnce characteristics when concatenating using dask
                 if pd.api.types.is_extension_array_dtype(getattr(adata, attr)[col].dtype):
-                    setattr(getattr(adata, attr), col, getattr(adata, attr)[col].data)
+                    getattr(adata, attr)[col] = getattr(adata, attr)[col].data)
     return adata
 
 


### PR DESCRIPTION
@felix0097 Beyond this being a bug against the original intention, this should account for the performance drop we saw (and what I saw over what I tried out on DENBI).  `obs['foo'] = ...` != `setattr(obs, 'foo', ...) agh!