### PR TITLE
feat: Make it optional to provide `splits` for Sampler in LoadRequest

### DIFF
--- a/src/annbatch/abc/sampler.py
+++ b/src/annbatch/abc/sampler.py
@@ -40,7 +40,9 @@ class Sampler(ABC):
     @property
     @abstractmethod
     def shuffle(self) -> bool | None:
-        """Whether to shuffle in memory data during sampling.
+        """Whether data is shuffled.
+        
+        If `batch_size` is provided and {attr}`annbatch.types.LoadRequest.splits` is not, in-memory loaded data will be shuffled or not based on this param.
 
         Shuffling of on-disk data is up to the user (controlled by `chunks` parameter in {class}`annbatch.types.LoadRequest`).
 

--- a/src/annbatch/abc/sampler.py
+++ b/src/annbatch/abc/sampler.py
@@ -39,7 +39,7 @@ class Sampler(ABC):
 
     @property
     @abstractmethod
-    def shuffle(self) -> bool | None:
+    def shuffle(self) -> bool:
         """Whether data is shuffled.
         
         If `batch_size` is provided and {attr}`annbatch.types.LoadRequest.splits` is not, in-memory loaded data will be shuffled or not based on this param.

--- a/src/annbatch/abc/sampler.py
+++ b/src/annbatch/abc/sampler.py
@@ -27,7 +27,7 @@ class Sampler(ABC):
         Note
         ----
         This property is only used when the `splits` argument is not supplied
-        in the LoadRequest. When `splits` are explicitly provided, they determine
+        in the {class}`annbatch.types.LoadRequest`. When `splits` are explicitly provided, they determine
         the batch boundaries instead.
 
         Returns

--- a/src/annbatch/abc/sampler.py
+++ b/src/annbatch/abc/sampler.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -16,6 +18,23 @@ class Sampler(ABC):
 
     Samplers control how data is batched and loaded from the underlying datasets.
     """
+
+    @property
+    @abstractmethod
+    def batch_size(self) -> int | None:
+        """The batch size for data loading.
+
+        Note
+        ----
+        This property is only used when the `splits` argument is not supplied
+        in the LoadRequest. When `splits` are explicitly provided, they determine
+        the batch boundaries instead.
+
+        Returns
+        -------
+        int
+            The number of observations per batch.
+        """
 
     def sample(self, n_obs: int) -> Iterator[LoadRequest]:
         """Sample load requests given the total number of observations.
@@ -31,7 +50,27 @@ class Sampler(ABC):
             Load requests for batching data.
         """
         self.validate(n_obs)
-        yield from self._sample(n_obs)
+        for load_request in self._sample(n_obs):
+            # If splits are not provided, generate them based on batch_size
+            if "splits" not in load_request or load_request["splits"] is None:
+                batch_size = self.batch_size
+                if batch_size is None:
+                    raise ValueError("batch_size must be set when splits are not provided in LoadRequest")
+
+                # Calculate total observations from chunks
+                total_obs = sum(chunk.stop - chunk.start for chunk in load_request["chunks"])
+
+                # Generate random permutation and split into batches
+                indices = np.random.permutation(total_obs)
+                splits = []
+                for i in range(0, total_obs, batch_size):
+                    batch_indices = indices[i : i + batch_size]
+                    if len(batch_indices) > 0:  # Ensure non-empty batches
+                        splits.append(batch_indices)
+
+                load_request["splits"] = splits
+
+            yield load_request
 
     @abstractmethod
     def validate(self, n_obs: int) -> None:

--- a/src/annbatch/abc/sampler.py
+++ b/src/annbatch/abc/sampler.py
@@ -52,7 +52,7 @@ class Sampler(ABC):
         self.validate(n_obs)
         for load_request in self._sample(n_obs):
             # If splits are not provided, generate them based on batch_size
-            if "splits" not in load_request or load_request["splits"] is None:
+            if "splits" not in load_request:
                 batch_size = self.batch_size
                 if batch_size is None:
                     raise ValueError("batch_size must be set when splits are not provided in LoadRequest")

--- a/src/annbatch/samplers/_chunk_sampler.py
+++ b/src/annbatch/samplers/_chunk_sampler.py
@@ -89,6 +89,10 @@ class ChunkSampler(Sampler):
             drop_last,
         )
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     def validate(self, n_obs: int) -> None:
         """Validate the sampler configuration against the loader's n_obs.
 

--- a/src/annbatch/samplers/_chunk_sampler.py
+++ b/src/annbatch/samplers/_chunk_sampler.py
@@ -93,6 +93,10 @@ class ChunkSampler(Sampler):
     def batch_size(self) -> int:
         return self._batch_size
 
+    @property
+    def shuffle(self) -> bool:
+        return self._shuffle
+
     def validate(self, n_obs: int) -> None:
         """Validate the sampler configuration against the loader's n_obs.
 

--- a/src/annbatch/types.py
+++ b/src/annbatch/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 import anndata as ad
 import numpy as np
@@ -29,10 +29,11 @@ class LoadRequest(TypedDict):
     splits
         How the in-memory data should be split into batches after it is read off disk and concatenated in-memory.
         A list of splits, last one may be partial but not empty i.e. 1 <= len(last_split) <= batch_size.
+        If not provided, the sampler's batch_size property will be used to automatically generate splits.
     """
 
     chunks: list[slice]
-    splits: list[np.ndarray]
+    splits: NotRequired[list[np.ndarray]]
 
 
 class LoaderOutput[OutputInMemoryArray: OutputInMemoryArray_T](TypedDict):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -527,6 +527,10 @@ def test_add_dataset_validation_failure_preserves_state(adata_with_zarr_path_sam
             return 10
 
         @property
+        def shuffle(self) -> bool:
+            return False
+
+        @property
         def worker_handle(self):
             return None
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -316,7 +316,7 @@ def test_explicit_splits_override_automatic_batching():
 
 
 @pytest.mark.parametrize("shuffle", [False, True])
-def test_automatic_batching_respects_shuffle_flag(shuffle):
+def test_automatic_batching_respects_shuffle_flag(shuffle: bool):
     """Test automatic batching generates splits and respects shuffle parameter."""
     batch_size, n_obs = 3, 25
     sampler = SimpleSampler(batch_size=batch_size, provide_splits=False, shuffle=shuffle)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -296,7 +296,7 @@ class SimpleSampler(Sampler):
         pytest.param(3, None, id="missing_shuffle"),
     ],
 )
-def test_automatic_batching_requires_batch_size_and_shuffle(batch_size, shuffle):
+def test_automatic_batching_requires_batch_size_and_shuffle(batch_size: int, shuffle: bool):
     """Test that automatic batching raises error when batch_size or shuffle is None."""
     sampler = SimpleSampler(batch_size=batch_size, provide_splits=False, shuffle=shuffle)
     n_obs = 20


### PR DESCRIPTION
This PR makes it optional to provide `splits` in the `annbatch.types.LoadRequest`. 

The logic is the following:
* If `splits` is provided -> use splits
* If `splits` is not provided -> do random batching