### PR TITLE
Fix: ChunkSampler yields empty splits when remainder is less than batch_size and drop_last

### DIFF
--- a/src/annbatch/samplers/_chunk_sampler.py
+++ b/src/annbatch/samplers/_chunk_sampler.py
@@ -168,12 +168,12 @@ class ChunkSampler(Sampler):
         # On the last yield, drop the last uneven batch and create new batch_indices since the in-memory size of this last yield could be divisible by batch_size but smaller than preload_nslices * slice_size
         final_chunks = chunks_per_request[-1]
         total_obs_in_last_batch = int(sum(s.stop - s.start for s in final_chunks))
-        if total_obs_in_last_batch == 0: # pragma: no cover
+        if total_obs_in_last_batch == 0:  # pragma: no cover
             raise RuntimeError("Last batch was found to have no observations. Please open an issue.")
         if self._drop_last:
-        if total_obs_in_last_batch < self._batch_size:
-            return
-        total_obs_in_last_batch -= total_obs_in_last_batch % self._batch_size
+            if total_obs_in_last_batch < self._batch_size:
+                return
+            total_obs_in_last_batch -= total_obs_in_last_batch % self._batch_size
         batch_indices = split_given_size(
             (np.random.default_rng().permutation if self._shuffle else np.arange)(total_obs_in_last_batch),
             self._batch_size,

--- a/src/annbatch/samplers/_chunk_sampler.py
+++ b/src/annbatch/samplers/_chunk_sampler.py
@@ -156,20 +156,23 @@ class ChunkSampler(Sampler):
             chunks = worker_handle.get_part_for_worker(chunks)
         # Set up the iterator for chunks and the batch indices for splits
         in_memory_size = self._chunk_size * self._preload_nchunks
-        chunks_per_batch = split_given_size(chunks, self._preload_nchunks)
+        chunks_per_request = split_given_size(chunks, self._preload_nchunks)
         batch_indices = np.arange(in_memory_size)
         split_batch_indices = split_given_size(batch_indices, self._batch_size)
-        for batch_chunks in chunks_per_batch[:-1]:
+        for request_chunks in chunks_per_request[:-1]:
             if self._shuffle:
                 # Avoid copies using in-place shuffling since `self._shuffle` should not change mid-training
                 np.random.default_rng().shuffle(batch_indices)
                 split_batch_indices = split_given_size(batch_indices, self._batch_size)
-            yield {"chunks": batch_chunks, "splits": split_batch_indices}
+            yield {"chunks": request_chunks, "splits": split_batch_indices}
         # On the last yield, drop the last uneven batch and create new batch_indices since the in-memory size of this last yield could be divisible by batch_size but smaller than preload_nslices * slice_size
-        final_chunks = chunks_per_batch[-1]
+        final_chunks = chunks_per_request[-1]
         total_obs_in_last_batch = int(sum(s.stop - s.start for s in final_chunks))
         if self._drop_last:
             total_obs_in_last_batch -= total_obs_in_last_batch % self._batch_size
+        # Skip yielding if there are no observations (can happen with drop_last=True and last request is empty)
+        if total_obs_in_last_batch == 0:
+            return
         batch_indices = split_given_size(
             (np.random.default_rng().permutation if self._shuffle else np.arange)(total_obs_in_last_batch),
             self._batch_size,

--- a/src/annbatch/samplers/_chunk_sampler.py
+++ b/src/annbatch/samplers/_chunk_sampler.py
@@ -168,11 +168,13 @@ class ChunkSampler(Sampler):
         # On the last yield, drop the last uneven batch and create new batch_indices since the in-memory size of this last yield could be divisible by batch_size but smaller than preload_nslices * slice_size
         final_chunks = chunks_per_request[-1]
         total_obs_in_last_batch = int(sum(s.stop - s.start for s in final_chunks))
+        if total_obs_in_last_batch == 0: # pragma: no cover
+            raise RuntimeError("Last batch was found to have no observations. Please open an issue.")
         if self._drop_last:
             total_obs_in_last_batch -= total_obs_in_last_batch % self._batch_size
         # Skip yielding if there are no observations (can happen with drop_last=True and last request is empty)
-        if total_obs_in_last_batch == 0:
-            return
+            if total_obs_in_last_batch == 0:
+                return
         batch_indices = split_given_size(
             (np.random.default_rng().permutation if self._shuffle else np.arange)(total_obs_in_last_batch),
             self._batch_size,

--- a/src/annbatch/samplers/_chunk_sampler.py
+++ b/src/annbatch/samplers/_chunk_sampler.py
@@ -171,10 +171,9 @@ class ChunkSampler(Sampler):
         if total_obs_in_last_batch == 0: # pragma: no cover
             raise RuntimeError("Last batch was found to have no observations. Please open an issue.")
         if self._drop_last:
-            total_obs_in_last_batch -= total_obs_in_last_batch % self._batch_size
-        # Skip yielding if there are no observations (can happen with drop_last=True and last request is empty)
-            if total_obs_in_last_batch == 0:
-                return
+        if total_obs_in_last_batch < self._batch_size:
+            return
+        total_obs_in_last_batch -= total_obs_in_last_batch % self._batch_size
         batch_indices = split_given_size(
             (np.random.default_rng().permutation if self._shuffle else np.arange)(total_obs_in_last_batch),
             self._batch_size,

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -98,6 +98,10 @@ def test_mask_coverage(n_obs, chunk_size, start, stop, batch_size, preload_nchun
 
     expected_start = start if start is not None else 0
     expected_stop = stop if stop is not None else n_obs
+    if drop_last:
+        # With drop_last, only complete batches are yielded
+        total_obs = expected_stop - expected_start
+        expected_stop = expected_start + (total_obs // batch_size) * batch_size
     expected_indices = list(range(expected_start, expected_stop))
 
     all_indices = collect_indices(sampler, n_obs)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -56,32 +56,35 @@ class ChunkSamplerWithMockWorkerHandle(ChunkSampler):
 
 
 @pytest.mark.parametrize(
-    "n_obs,chunk_size,start,stop,batch_size,preload_nchunks,shuffle",
+    "n_obs,chunk_size,start,stop,batch_size,preload_nchunks,shuffle,drop_last",
     [
         # Basic full dataset
-        pytest.param(100, 10, None, None, 5, 2, False, id="full_dataset"),
+        pytest.param(100, 10, None, None, 5, 2, False, False, id="full_dataset"),
         # mask.start only
-        pytest.param(100, 10, 30, None, 5, 2, False, id="start_at_chunk_boundary"),
-        pytest.param(100, 10, 35, None, 5, 2, False, id="start_not_at_chunk_boundary"),
-        pytest.param(120, 12, 90, None, 3, 1, False, id="start_near_end"),
-        pytest.param(100, 10, 20, None, 5, 2, False, id="start_mask_stop_none"),
+        pytest.param(100, 10, 30, None, 5, 2, False, False, id="start_at_chunk_boundary"),
+        pytest.param(100, 10, 35, None, 5, 2, False, False, id="start_not_at_chunk_boundary"),
+        pytest.param(120, 12, 90, None, 3, 1, False, False, id="start_near_end"),
+        pytest.param(100, 10, 20, None, 5, 2, False, False, id="start_mask_stop_none"),
         # mask.stop only
-        pytest.param(50, 10, None, 50, 5, 2, False, id="stop_at_chunk_boundary"),
-        pytest.param(47, 10, None, 47, 5, 2, False, id="stop_not_at_chunk_boundary"),
+        pytest.param(50, 10, None, 50, 5, 2, False, False, id="stop_at_chunk_boundary"),
+        pytest.param(47, 10, None, 47, 5, 2, False, False, id="stop_not_at_chunk_boundary"),
         # Both bounds
-        pytest.param(60, 10, 20, 60, 5, 2, False, id="both_at_chunk_boundaries"),
-        pytest.param(67, 10, 23, 67, 5, 2, False, id="both_not_at_chunk_boundaries"),
-        pytest.param(28, 10, 22, 28, 2, 1, False, id="single_chunk_span"),
-        pytest.param(100, 10, 15, 85, 5, 2, False, id="both_non_aligned"),
-        pytest.param(100, 10, 20, 80, 5, 2, False, id="both_aligned"),
+        pytest.param(60, 10, 20, 60, 5, 2, False, False, id="both_at_chunk_boundaries"),
+        pytest.param(67, 10, 23, 67, 5, 2, False, False, id="both_not_at_chunk_boundaries"),
+        pytest.param(28, 10, 22, 28, 2, 1, False, False, id="single_chunk_span"),
+        pytest.param(100, 10, 15, 85, 5, 2, False, False, id="both_non_aligned"),
+        pytest.param(100, 10, 20, 80, 5, 2, False, False, id="both_aligned"),
         # Edge cases
-        pytest.param(100, 10, 95, 100, 10, 1, False, id="very_small_mask"),
+        pytest.param(100, 10, 95, 100, 10, 1, False, False, id="very_small_mask"),
         # With shuffle
-        pytest.param(100, 10, 30, None, 5, 2, True, id="shuffle_with_start"),
-        pytest.param(75, 10, 25, 75, 5, 2, True, id="shuffle_with_both_bounds"),
+        pytest.param(100, 10, 30, None, 5, 2, True, False, id="shuffle_with_start"),
+        pytest.param(75, 10, 25, 75, 5, 2, True, False, id="shuffle_with_both_bounds"),
+        # drop_last edge cases: remainder less than batch_size
+        pytest.param(45, 20, None, None, 10, 2, False, True, id="drop_last_remainder_less_than_batch"),
+        pytest.param(5, 20, None, None, 10, 2, False, True, id="drop_last_total_less_than_batch"),
     ],
 )
-def test_mask_coverage(n_obs, chunk_size, start, stop, batch_size, preload_nchunks, shuffle):
+def test_mask_coverage(n_obs, chunk_size, start, stop, batch_size, preload_nchunks, shuffle, drop_last):
     """Test sampler covers exactly the expected range, and ordering is correct when not shuffled."""
     sampler = ChunkSampler(
         mask=slice(start, stop),
@@ -89,6 +92,7 @@ def test_mask_coverage(n_obs, chunk_size, start, stop, batch_size, preload_nchun
         chunk_size=chunk_size,
         preload_nchunks=preload_nchunks,
         shuffle=shuffle,
+        drop_last=drop_last,
         rng=np.random.default_rng(42) if shuffle else None,
     )
 


### PR DESCRIPTION
You can try out the tests in https://github.com/scverse/annbatch/commit/51d41759a343d5e41ea3404dc68b9df349d774ef and see how it yields empty splits