### PR TITLE
Change [tool.pytest.ini_option] to  [tool.pytest.ini_options] in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ lint.per-file-ignores."docs/*" = [ "I" ]
 lint.per-file-ignores."tests/*" = [ "D" ]
 lint.pydocstyle.convention = "numpy"
 
-[tool.pytest.ini_option]
+[tool.pytest.ini_options]
 markers = [ "gpu: mark test to run on GPU" ]
 testpaths = [ "tests" ]
 xfail_strict = true

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -413,7 +413,7 @@ def test_3d(
             import torch
 
             assert isinstance(x, torch.Tensor)
-            x = np.array(x.cpu())
+            x = x.cpu().numpy()
         x_list.append(x)
         idx_list.append(idxs.ravel())
     x = np.vstack(x_list)


### PR DESCRIPTION
I get this warning localy
```
../../mambaforge/envs/annbatch/lib/python3.13/site-packages/_pytest/config/__init__.py:1428
  /Users/selman.ozleyen/mambaforge/envs/annbatch/lib/python3.13/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: ini_option
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
```
 
when I change [tool.pytest.ini_option] to `[tool.pytest.ini_options]` it doesn’t warn (edited) 

https://docs.pytest.org/en/stable/reference/customize.html

cc: @ilan-gold 