### PR TITLE
Bug fix: `Loader.__len__` returns wrong length

### DIFF
--- a/src/annbatch/abc/sampler.py
+++ b/src/annbatch/abc/sampler.py
@@ -41,7 +41,7 @@ class Sampler(ABC):
     @abstractmethod
     def shuffle(self) -> bool:
         """Whether data is shuffled.
-        
+
         If `batch_size` is provided and {attr}`annbatch.types.LoadRequest.splits` is not, in-memory loaded data will be shuffled or not based on this param.
 
         Shuffling of on-disk data is up to the user (controlled by `chunks` parameter in {class}`annbatch.types.LoadRequest`).
@@ -50,6 +50,21 @@ class Sampler(ABC):
         -------
         bool
             True if data should be shuffled, False otherwise.
+        """
+
+    @abstractmethod
+    def n_iters(self, n_obs: int) -> int:
+        """Return the number of batches.
+
+        Parameters
+        ----------
+        n_obs
+            The total number of observations available.
+
+        Returns
+        -------
+        int
+            The total number of batches this sampler will produce.
         """
 
     def sample(self, n_obs: int) -> Iterator[LoadRequest]:

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -212,7 +212,7 @@ class Loader[
         self._concat_strategy = concat_strategy
 
     def __len__(self) -> int:
-        return self.n_obs
+        return self._batch_sampler.n_iters(self.n_obs)
 
     @property
     def _sp_module(self) -> ModuleType:

--- a/src/annbatch/samplers/_chunk_sampler.py
+++ b/src/annbatch/samplers/_chunk_sampler.py
@@ -97,6 +97,11 @@ class ChunkSampler(Sampler):
     def shuffle(self) -> bool:
         return self._shuffle
 
+    def n_iters(self, n_obs: int) -> int:
+        start, stop = self._mask.start or 0, self._mask.stop or n_obs
+        total_obs = stop - start
+        return total_obs // self._batch_size if self._drop_last else math.ceil(total_obs / self._batch_size)
+
     def validate(self, n_obs: int) -> None:
         """Validate the sampler configuration against the loader's n_obs.
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from importlib.util import find_spec
 from types import NoneType
 from typing import TYPE_CHECKING, TypedDict
@@ -516,6 +517,9 @@ def test_add_dataset_validation_failure_preserves_state(adata_with_zarr_path_sam
 
         def __init__(self):
             self._validate_count = 0
+
+        def n_iters(self, n_obs: int) -> int:
+            return math.ceil(n_obs / self.batch_size)
 
         def validate(self, n_obs: int) -> None:
             self._validate_count += 1

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -323,6 +323,45 @@ def test_drop_last(adata_with_zarr_path_same_var_space: tuple[ad.AnnData, Path],
     np.testing.assert_allclose(X, X_expected)
 
 
+@pytest.mark.parametrize("drop_last", [True, False], ids=["drop", "kept"])
+@pytest.mark.parametrize(
+    ("chunk_size", "preload_nchunks", "batch_size"),
+    [
+        (10, 3, 10),  # batch_size divides evenly
+        (14, 3, 21),  # batch_size does not divide evenly
+        (10, 5, 25),  # larger preload
+    ],
+)
+def test_len(
+    adata_with_zarr_path_same_var_space: tuple[ad.AnnData, Path],
+    drop_last: bool,
+    chunk_size: int,
+    preload_nchunks: int,
+    batch_size: int,
+):
+    zarr_path = next(adata_with_zarr_path_same_var_space[1].glob("*.zarr"))
+    data = open_sparse(zarr_path)
+    n_obs = data["dataset"].shape[0]
+
+    loader = Loader(
+        shuffle=False,
+        chunk_size=chunk_size,
+        preload_nchunks=preload_nchunks,
+        batch_size=batch_size,
+        preload_to_gpu=False,
+        to_torch=False,
+        drop_last=drop_last,
+    )
+    loader.add_dataset(**data)
+
+    expected_len = n_obs // batch_size if drop_last else math.ceil(n_obs / batch_size)
+    assert len(loader) == expected_len
+
+    # Also verify len matches the actual number of yielded batches
+    actual_batches = sum(1 for _ in loader)
+    assert len(loader) == actual_batches
+
+
 def test_bad_adata_X_hdf5(adata_with_h5_path_different_var_space: tuple[ad.AnnData, Path]):
     with h5py.File(next(adata_with_h5_path_different_var_space[1].glob("*.h5ad"))) as f:
         data = ad.io.sparse_dataset(f["X"])

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytest
 
@@ -274,6 +276,11 @@ class SimpleSampler(Sampler):
     @property
     def shuffle(self) -> bool | None:
         return self._shuffle
+
+    def n_iters(self, n_obs: int) -> int:
+        if self._batch_size is None or self._batch_size == 0:
+            return 1
+        return math.ceil(n_obs / self._batch_size)
 
     def validate(self, n_obs: int) -> None:
         """No validation needed for test sampler."""


### PR DESCRIPTION
In the current implementation `Loader.__len__` returns `n_obs` instead to the number of batches. This PR should fix this