### PR TITLE
feat: Add distributed version of `ChunkSampler`

### DIFF
--- a/src/annbatch/__init__.py
+++ b/src/annbatch/__init__.py
@@ -5,7 +5,7 @@ from importlib.metadata import version
 from . import abc, types
 from .io import DatasetCollection, write_sharded
 from .loader import Loader
-from .samplers._chunk_sampler import ChunkSampler, ChunkSamplerTorchDistributed
+from .samplers._chunk_sampler import ChunkSampler, ChunkSamplerDistributed
 
 __version__ = version("annbatch")
 
@@ -15,6 +15,6 @@ __all__ = [
     "types",
     "write_sharded",
     "ChunkSampler",
-    "ChunkSamplerTorchDistributed",
+    "ChunkSamplerDistributed",
     "abc",
 ]

--- a/src/annbatch/__init__.py
+++ b/src/annbatch/__init__.py
@@ -5,7 +5,7 @@ from importlib.metadata import version
 from . import abc, types
 from .io import DatasetCollection, write_sharded
 from .loader import Loader
-from .samplers._chunk_sampler import ChunkSampler
+from .samplers._chunk_sampler import ChunkSampler, ChunkSamplerTorchDistributed
 
 __version__ = version("annbatch")
 
@@ -15,5 +15,6 @@ __all__ = [
     "types",
     "write_sharded",
     "ChunkSampler",
+    "ChunkSamplerTorchDistributed",
     "abc",
 ]

--- a/src/annbatch/samplers/__init__.py
+++ b/src/annbatch/samplers/__init__.py
@@ -1,5 +1,6 @@
-from ._chunk_sampler import ChunkSampler
+from ._chunk_sampler import ChunkSampler, ChunkSamplerTorchDistributed
 
 __all__ = [
     "ChunkSampler",
+    "ChunkSamplerTorchDistributed",
 ]

--- a/src/annbatch/samplers/__init__.py
+++ b/src/annbatch/samplers/__init__.py
@@ -1,6 +1,6 @@
-from ._chunk_sampler import ChunkSampler, ChunkSamplerTorchDistributed
+from ._chunk_sampler import ChunkSampler, ChunkSamplerDistributed
 
 __all__ = [
     "ChunkSampler",
-    "ChunkSamplerTorchDistributed",
+    "ChunkSamplerDistributed",
 ]


### PR DESCRIPTION
This PR adds an extension of the `ChunkSampler` class that shards the dataset for training using `torch.distributed`.