### PR TITLE
fix: `torch` 2.11 compat

### DIFF
--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -160,10 +160,12 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
     if isinstance(input, torch.Tensor):
         return input
     if isinstance(input, sp.sparse.csr_matrix):
-        with torch.sparse.check_sparse_tensor_invariants(enable=True):
+        # TODO: better way to toggle this off for "production" but on for tests?
+        with torch.sparse.check_sparse_tensor_invariants(enable=False):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
                 # https://github.com/pytorch/pytorch/issues/178309
+                # Without this, under `enable=True` above, there would be the above error.
                 if input.nnz == 0:
                     indptr = torch.from_numpy(input.indptr)
                     tensor = torch.sparse_csr_tensor(

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -167,6 +167,7 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
                 torch.from_numpy(input.indices),
                 torch.from_numpy(input.data),
                 input.shape,
+                check_invariants=True,
             )
         if preload_to_gpu:
             return tensor.cuda(non_blocking=True)
@@ -186,6 +187,7 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
                 torch.from_dlpack(input.indices),
                 torch.from_dlpack(input.data),
                 input.shape,
+                check_invariants=True,
             )
     raise TypeError(f"Cannot convert {type(input)} to torch.Tensor")
 

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -166,8 +166,8 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
                 torch.from_numpy(input.indptr),
                 torch.from_numpy(input.indices),
                 torch.from_numpy(input.data),
-                input.shape,
-                check_invariants=True,
+                size=input.shape,
+                check_invariants=False,
             )
         if preload_to_gpu:
             return tensor.cuda(non_blocking=True)
@@ -186,8 +186,8 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
                 torch.from_dlpack(input.indptr),
                 torch.from_dlpack(input.indices),
                 torch.from_dlpack(input.data),
-                input.shape,
-                check_invariants=True,
+                size=input.shape,
+                check_invariants=False,
             )
     raise TypeError(f"Cannot convert {type(input)} to torch.Tensor")
 

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -156,40 +156,38 @@ def check_var_shapes(objs: list[SupportsShape]) -> None:
 def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
     """Send the input data to a torch.Tensor"""
     import torch
-
-    if isinstance(input, torch.Tensor):
-        return input
-    if isinstance(input, sp.sparse.csr_matrix):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
-            tensor = torch.sparse_csr_tensor(
-                torch.from_numpy(input.indptr),
-                torch.from_numpy(input.indices),
-                torch.from_numpy(input.data),
-                size=input.shape,
-                check_invariants=False,
-            )
-        if preload_to_gpu:
-            return tensor.cuda(non_blocking=True)
-        return tensor
-    if isinstance(input, np.ndarray):
-        tensor = torch.from_numpy(input)
-        if preload_to_gpu:
-            return tensor.cuda(non_blocking=True)
-        return tensor
-    if isinstance(input, CupyArray):
-        return torch.from_dlpack(input)
-    if isinstance(input, CupyCSRMatrix):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
-            return torch.sparse_csr_tensor(
-                torch.from_dlpack(input.indptr),
-                torch.from_dlpack(input.indices),
-                torch.from_dlpack(input.data),
-                size=input.shape,
-                check_invariants=False,
-            )
-    raise TypeError(f"Cannot convert {type(input)} to torch.Tensor")
+    with torch.sparse.check_sparse_tensor_invariants(enable=False):
+        if isinstance(input, torch.Tensor):
+            return input
+        if isinstance(input, sp.sparse.csr_matrix):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
+                tensor = torch.sparse_csr_tensor(
+                    torch.from_numpy(input.indptr),
+                    torch.from_numpy(input.indices),
+                    torch.from_numpy(input.data),
+                    size=input.shape,
+                )
+            if preload_to_gpu:
+                return tensor.cuda(non_blocking=True)
+            return tensor
+        if isinstance(input, np.ndarray):
+            tensor = torch.from_numpy(input)
+            if preload_to_gpu:
+                return tensor.cuda(non_blocking=True)
+            return tensor
+        if isinstance(input, CupyArray):
+            return torch.from_dlpack(input)
+        if isinstance(input, CupyCSRMatrix):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
+                return torch.sparse_csr_tensor(
+                    torch.from_dlpack(input.indptr),
+                    torch.from_dlpack(input.indices),
+                    torch.from_dlpack(input.data),
+                    size=input.shape,
+                )
+        raise TypeError(f"Cannot convert {type(input)} to torch.Tensor")
 
 
 def load_x_and_obs_and_var(g: zarr.Group) -> ad.AnnData:

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -156,6 +156,7 @@ def check_var_shapes(objs: list[SupportsShape]) -> None:
 def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
     """Send the input data to a torch.Tensor"""
     import torch
+
     with torch.sparse.check_sparse_tensor_invariants(enable=False):
         if isinstance(input, torch.Tensor):
             return input

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -157,38 +157,39 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
     """Send the input data to a torch.Tensor"""
     import torch
 
-    with torch.sparse.check_sparse_tensor_invariants(enable=False):
-        if isinstance(input, torch.Tensor):
-            return input
-        if isinstance(input, sp.sparse.csr_matrix):
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
+    if isinstance(input, torch.Tensor):
+        return input
+    if isinstance(input, sp.sparse.csr_matrix):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
+            with torch.sparse.check_sparse_tensor_invariants(enable=False):
                 tensor = torch.sparse_csr_tensor(
                     torch.from_numpy(input.indptr),
                     torch.from_numpy(input.indices),
                     torch.from_numpy(input.data),
                     size=input.shape,
                 )
-            if preload_to_gpu:
-                return tensor.cuda(non_blocking=True)
-            return tensor
-        if isinstance(input, np.ndarray):
-            tensor = torch.from_numpy(input)
-            if preload_to_gpu:
-                return tensor.cuda(non_blocking=True)
-            return tensor
-        if isinstance(input, CupyArray):
-            return torch.from_dlpack(input)
-        if isinstance(input, CupyCSRMatrix):
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
+        if preload_to_gpu:
+            return tensor.cuda(non_blocking=True)
+        return tensor
+    if isinstance(input, np.ndarray):
+        tensor = torch.from_numpy(input)
+        if preload_to_gpu:
+            return tensor.cuda(non_blocking=True)
+        return tensor
+    if isinstance(input, CupyArray):
+        return torch.from_dlpack(input)
+    if isinstance(input, CupyCSRMatrix):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
+            with torch.sparse.check_sparse_tensor_invariants(enable=False):
                 return torch.sparse_csr_tensor(
                     torch.from_dlpack(input.indptr),
                     torch.from_dlpack(input.indices),
                     torch.from_dlpack(input.data),
                     size=input.shape,
                 )
-        raise TypeError(f"Cannot convert {type(input)} to torch.Tensor")
+    raise TypeError(f"Cannot convert {type(input)} to torch.Tensor")
 
 
 def load_x_and_obs_and_var(g: zarr.Group) -> ad.AnnData:

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -163,12 +163,23 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
         with torch.sparse.check_sparse_tensor_invariants(enable=True):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
-                tensor = torch.sparse_csr_tensor(
-                    torch.from_numpy(input.indptr),
-                    torch.from_numpy(input.indices),
-                    torch.from_numpy(input.data),
-                    size=input.shape,
-                )
+                # https://github.com/pytorch/pytorch/issues/178309
+                if input.nnz == 0:
+                    indptr = torch.from_numpy(input.indptr)
+                    tensor = torch.sparse_csr_tensor(
+                        indptr,
+                        torch.tensor([], dtype=indptr.dtype),
+                        torch.tensor([]),
+                        size=input.shape,
+                        dtype=torch.from_numpy(input.data).dtype,  # TODO: better way to do this?
+                    )
+                else:
+                    tensor = torch.sparse_csr_tensor(
+                        torch.from_numpy(input.indptr),
+                        torch.from_numpy(input.indices),
+                        torch.from_numpy(input.data),
+                        size=input.shape,
+                    )
             if preload_to_gpu:
                 return tensor.cuda(non_blocking=True)
             return tensor

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -160,7 +160,7 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
     if isinstance(input, torch.Tensor):
         return input
     if isinstance(input, sp.sparse.csr_matrix):
-        with torch.sparse.check_sparse_tensor_invariants(enable=False):
+        with torch.sparse.check_sparse_tensor_invariants(enable=True):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
                 tensor = torch.sparse_csr_tensor(

--- a/src/annbatch/utils.py
+++ b/src/annbatch/utils.py
@@ -160,18 +160,18 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
     if isinstance(input, torch.Tensor):
         return input
     if isinstance(input, sp.sparse.csr_matrix):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
-            with torch.sparse.check_sparse_tensor_invariants(enable=False):
+        with torch.sparse.check_sparse_tensor_invariants(enable=False):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
                 tensor = torch.sparse_csr_tensor(
                     torch.from_numpy(input.indptr),
                     torch.from_numpy(input.indices),
                     torch.from_numpy(input.data),
                     size=input.shape,
                 )
-        if preload_to_gpu:
-            return tensor.cuda(non_blocking=True)
-        return tensor
+            if preload_to_gpu:
+                return tensor.cuda(non_blocking=True)
+            return tensor
     if isinstance(input, np.ndarray):
         tensor = torch.from_numpy(input)
         if preload_to_gpu:
@@ -182,13 +182,12 @@ def to_torch(input: OutputInMemoryArray_T, preload_to_gpu: bool) -> Tensor:
     if isinstance(input, CupyCSRMatrix):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
-            with torch.sparse.check_sparse_tensor_invariants(enable=False):
-                return torch.sparse_csr_tensor(
-                    torch.from_dlpack(input.indptr),
-                    torch.from_dlpack(input.indices),
-                    torch.from_dlpack(input.data),
-                    size=input.shape,
-                )
+            return torch.sparse_csr_tensor(
+                torch.from_dlpack(input.indptr),
+                torch.from_dlpack(input.indices),
+                torch.from_dlpack(input.data),
+                size=input.shape,
+            )
     raise TypeError(f"Cannot convert {type(input)} to torch.Tensor")
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -269,6 +269,7 @@ def test_use_collection_twice(simple_collection: tuple[ad.AnnData, DatasetCollec
         ),
         False,
     ],
+    ids=["preload_to_gpu", "dont_preload_to_gpu"],
 )
 @pytest.mark.parametrize("open_func", [open_sparse, open_dense])
 def test_to_torch(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -415,9 +415,9 @@ def test_torch_multiprocess_dataloading_zarr(
 
 
 @pytest.mark.parametrize(
-    "preload_to_gpu", [False, pytest.param(True, marks=[pytest.mark.gpu, skip_if_no_cupy])], ids=["cupy", "no_cupy"]
+    "preload_to_gpu", [False, pytest.param(True, marks=[pytest.mark.gpu, skip_if_no_cupy])], ids=["no_cupy", "cupy"]
 )
-@pytest.mark.parametrize("to_torch", [False, pytest.param(True, marks=[skip_if_no_torch])], ids=["torch", "no_torch"])
+@pytest.mark.parametrize("to_torch", [False, pytest.param(True, marks=[skip_if_no_torch])], ids=["no_torch", "torch"])
 def test_3d(
     adata_with_zarr_path_same_var_space: tuple[ad.AnnData, Path], use_zarrs: bool, preload_to_gpu: bool, to_torch: bool
 ):


### PR DESCRIPTION
Warnings raised in https://github.com/scverse/annbatch/actions/runs/23453294487/job/68235868436

Our sparse matrices should be valid and this sort of thing should be tested by all other tests.