### PR TITLE
fix: exclude torch 2.11 that is broken with cupy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.1.1]
+
+### Fixed
+
+- Exclude `torch` 2.11 on account of https://github.com/cupy/cupy/issues/9827
+
 ## [0.1.0]
 
 ### Breaking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ optional-dependencies.test = [
   "pytest",
 ]
 optional-dependencies.torch = [
-  "torch>=2,!=2.11.0",
+  "torch>=2,!=2.11",
 ]
 optional-dependencies.zarrs = [
   "zarrs>=0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ optional-dependencies.test = [
   "pytest",
 ]
 optional-dependencies.torch = [
-  "torch>=2",
+  "torch>=2,!=2.11.0",
 ]
 optional-dependencies.zarrs = [
   "zarrs>=0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ optional-dependencies.test = [
   "pytest",
 ]
 optional-dependencies.torch = [
+  # https://github.com/cupy/cupy/issues/9827
   "torch>=2,!=2.11",
 ]
 optional-dependencies.zarrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "annbatch"
-version = "0.1.0"
+version = "0.1.1"
 description = "A minibatch loader for AnnData stores"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
See https://github.com/cupy/cupy/issues/9827