### PR TITLE
fix: remove `TypeAliasType` from `nitpick_ignore`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,11 +130,10 @@ html_theme_options = {
 
 pygments_style = "default"
 
-nitpick_ignore = [
+nitpick_ignore: list[str] = [
     # If building the documentation fails because of a missing link that is outside your control,
     # you can add an exception to this list.
     #     ("py:class", "igraph.Graph"),
-    ("py:class", "annbatch.types.TypeAliasType")
 ]
 
 qualname_overrides = {


### PR DESCRIPTION
Originally had to be there becaue of https://github.com/sphinx-doc/sphinx/pull/13508 and https://github.com/sphinx-doc/sphinx/issues/11561