### PR TITLE
fix: cleaner compat for `torch<=2.11`

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Install annbatch
         run: |
           uv venv
-          uv pip install -e ".[test,${{ matrix.extras }}]" pytest-xdist${{ (contains(matrix.extras, '12') && contains(matrix.extras, 'torch') && ' --extra-index-url https://download.pytorch.org/whl/cu128 --index-strategy unsafe-best-match') || '' }}
+          uv pip install -e ".[test,${{ matrix.extras }}]" pytest-xdist
 
       - name: Env list
         run: uv pip list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Fixed
 
-- Error out with `torch>=2.11` + `cupy-cuda12x`.  To install both, you need to pass in something like `--extra-index-url https://download.pytorch.org/whl/cu128 --index-strategy unsafe-best-match'`.  We may start providing matched `torch->cupy` extras in 0.2.0 or exclude `cupy-cuda12x` entirely.
+- To handle `torch>=2.11` + `cupy-cuda12x`, because `torch` installs `cuda13` by default from this version onwards, we now install `cupy-cuda12x[ctk]` to ensure the `cuda` version used matches that of `cupy`.  For information on this change [see the cupy docs](https://docs.cupy.dev/en/stable/install.html#installing-cupy).
 
 ## [0.1.1]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
   "zarr>=3.1.4",
 ]
 optional-dependencies.cupy-cuda12 = [
-  "cupy-cuda12x",
+  "cupy-cuda12x[ctk]",
 ]
 optional-dependencies.cupy-cuda13 = [
-  "cupy-cuda13x",
+  "cupy-cuda13x[ctk]",
 ]
 optional-dependencies.dev = [
   "pre-commit",


### PR DESCRIPTION
[This seems to be recommended](https://docs.cupy.dev/en/stable/install.html#installing-cupy)

```
By default, the above command only installs CuPy itself, assuming a CUDA Toolkit is already installed on the system. 
To use NVIDIA’s CUDA component wheels (so as to quickly spinning up a fresh virtual environment without installing a
system-wide CUDA Toolkit – only the CUDA driver is needed – and allowing smaller installation footprint and better
interoperability with other Python GPU libraries), you can pass [ctk] to install them all as optional dependencies
```

cc @intron7