### PR TITLE
feat: splits are now rectified so they can be applied in LoadRequest.chunks/requests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.2.0]
+
+### Breaking
+- {attr}`annbatch.types.LoadRequest.splits` now index in **chunk order** -- position `j` is the `j`-th observation when the request's `chunks` are concatenated in the order given. Previously, `splits` had to index into the loader's internal dataset-grouped memory layout. The {class}`~annbatch.Loader` now remaps splits to that layout itself, so custom samplers must produce chunk-order splits and stop compensating for the dataset reordering. The built-in {class}`~annbatch.samplers.RandomSampler` and {class}`~annbatch.samplers.SequentialSampler` are unaffected.
+
+
 ## [0.1.6]
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [0.2.0]
 
 ### Breaking
-- {attr}`annbatch.types.LoadRequest.splits` now index in **chunk order** -- position `j` is the `j`-th observation when the request's `chunks` are concatenated in the order given. Previously, `splits` had to index into the loader's internal dataset-grouped memory layout. The {class}`~annbatch.Loader` now remaps splits to that layout itself, so custom samplers must produce chunk-order splits and stop compensating for the dataset reordering. The built-in {class}`~annbatch.samplers.RandomSampler` and {class}`~annbatch.samplers.SequentialSampler` are unaffected.
-
+- {attr}`annbatch.types.LoadRequest.splits` now index in **chunk order** -- position `j` is the `j`-th observation when the request's `chunks` are concatenated in the order given. Previously, `splits` had to index into the loader's internal dataset-grouped memory layout. The {class}`~annbatch.Loader` now remaps splits to that layout itself, so custom samplers must produce chunk-order splits and stop compensating for the dataset reordering.
 
 ## [0.1.6]
 

--- a/docs/custom-sampler.md
+++ b/docs/custom-sampler.md
@@ -44,9 +44,9 @@ This `TypedDict` is what {meth}`annbatch.abc.Sampler._sample` yields and specifi
   **Important:** The number of samples that get loaded into memory at once, must be devisible by the batch size.
   Otherwise, the remainder will yield to a smaller batch size or will be dropped if `drop_last=True`.
 
-- **{attr}`~annbatch.types.LoadRequest`** (optional): A list of numpy arrays that define how the loaded data should be split into batches after being read from disk.
+- **{attr}`~annbatch.types.LoadRequest`** (optional): A list of numpy arrays that define how the loaded data should be split into batches after being read from disk and concatenated in memory.
   - If not supplied: batches are randomly created based on the loaded chunks.
-  - If supplied: you can control how batches are created from the loaded chunks. Each array contains indices in **chunk order** -- position `j` is the `j`-th observation when the chunks are concatenated in the order listed in `chunks` (exactly as drawn below).
+  - If supplied: you can control how batches are created from the in-memory chunks. Each array contains indices in **chunk order** -- position `j` is the `j`-th observation when the chunks are concatenated in the order listed in `chunks` (exactly as drawn below).
 ```{note}
 The `splits` parameter gives you fine-grained control over how individual batches are created based on the loaded chunks. This capability is particularly useful when you want to organize batches based on semantic labels, categories, or other metadata.
 ```

--- a/docs/custom-sampler.md
+++ b/docs/custom-sampler.md
@@ -44,11 +44,16 @@ This `TypedDict` is what {meth}`annbatch.abc.Sampler._sample` yields and specifi
   **Important:** The number of samples that get loaded into memory at once, must be devisible by the batch size.
   Otherwise, the remainder will yield to a smaller batch size or will be dropped if `drop_last=True`.
 
-- **{attr}`~annbatch.types.LoadRequest`** (optional): A list of numpy arrays that define how the loaded data should be split into batches after being read from disk and concatenated in memory.
+- **{attr}`~annbatch.types.LoadRequest`** (optional): A list of numpy arrays that define how the loaded data should be split into batches after being read from disk.
   - If not supplied: batches are randomly created based on the loaded chunks.
-  - If supplied: you can control how batches are created from the in-memory chunks. Each array contains indices that map into the concatenated in-memory data.
+  - If supplied: you can control how batches are created from the loaded chunks. Each array contains indices in **chunk order** -- position `j` is the `j`-th observation when the chunks are concatenated in the order listed in `chunks` (exactly as drawn below).
 ```{note}
 The `splits` parameter gives you fine-grained control over how individual batches are created based on the loaded chunks. This capability is particularly useful when you want to organize batches based on semantic labels, categories, or other metadata.
+```
+```{important}
+Split indices are always in **chunk order**. Internally the loader fetches chunks grouped by on-disk dataset for efficiency, so the physical in-memory layout may be reordered, but it remaps your splits back to chunk order before yielding. You therefore never need to account for how chunks map to datasets.
+
+*Changed in 0.2.0:* splits previously had to index into the dataset-grouped physical layout; they now index in chunk order. Custom samplers that compensated for the dataset reordering must drop that compensation.
 ```
 
   ```

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -493,15 +493,23 @@ class Loader[
             A lookup between the dataset and its row indices, ordered by keys.
         """
         global_index = np.concatenate([np.arange(s.start, s.stop) for s in slices])
+
+        # Locate each requested row in its dataset by binary-searching the dataset boundaries,
+        sizes = np.fromiter((shape[0] for shape in self._shapes), dtype=np.int64, count=len(self._shapes))
+        ends = np.cumsum(sizes)
+        starts = ends - sizes
+        dataset_of_row = np.searchsorted(ends, global_index, side="right")
+
+        # Group rows by dataset: a stable sort keeps the within-dataset order
+        order = np.argsort(dataset_of_row, kind="stable")
+        grouped = dataset_of_row[order]
+        group_start = np.concatenate([[0], np.flatnonzero(np.diff(grouped)) + 1])
+        group_end = np.append(group_start[1:], grouped.size)
+
         result: OrderedDict[int, np.ndarray] = OrderedDict()
-        b_start = 0
-        for ds, shape in enumerate(self._shapes):
-            b_end = b_start + shape[0]
-            mask = (global_index >= b_start) & (global_index < b_end)
-            if mask.any():
-                offset = b_start
-                result[ds] = global_index[mask] - offset
-            b_start = b_end
+        for gs, ge in zip(group_start, group_end, strict=True):
+            ds = int(grouped[gs])
+            result[ds] = global_index[order[gs:ge]] - starts[ds]
         return result
 
     def _allocate_out(self, dataset_index_to_rows: OrderedDict[int, np.ndarray]) -> CSRContainer | np.ndarray:

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -478,7 +478,7 @@ class Loader[
             )
         return self
 
-    def _slices_to_dataset_rows(self, slices: list[slice]) -> OrderedDict[int, np.ndarray]:
+    def _slices_to_dataset_rows(self, slices: list[slice]) -> tuple[OrderedDict[int, np.ndarray], np.ndarray]:
         """Given a list of slices, give the lookup between on-disk datasets and row indices relative to that dataset.
 
         In the codebase we use slice and chunk interchangeably. Not to be confused with the zarr chunking/sharding terminology.
@@ -490,7 +490,9 @@ class Loader[
 
         Returns
         -------
-            A lookup between the dataset and its row indices, ordered by keys.
+            A lookup between the dataset and its row indices, ordered by keys, and the permutation
+            ``order`` mapping each in-memory buffer position to its index in the original chunk order
+            (the buffer is filled in dataset order, so ``order`` is what undoes that reordering).
         """
         global_index = np.concatenate([np.arange(s.start, s.stop) for s in slices])
 
@@ -510,7 +512,7 @@ class Loader[
         for gs, ge in zip(group_start, group_end, strict=True):
             ds = int(grouped[gs])
             result[ds] = global_index[order[gs:ge]] - starts[ds]
-        return result
+        return result, order
 
     def _allocate_out(self, dataset_index_to_rows: OrderedDict[int, np.ndarray]) -> CSRContainer | np.ndarray:
         """Preallocate a single contiguous output buffer covering all datasets and rows.
@@ -785,7 +787,13 @@ class Loader[
         for load_request in self._batch_sampler.sample(self.n_obs):
             chunks_to_load = load_request["chunks"]
             splits = load_request["splits"]
-            dataset_index_to_rows = self._slices_to_dataset_rows(chunks_to_load)
+            dataset_index_to_rows, order = self._slices_to_dataset_rows(chunks_to_load)
+
+            # The buffer below is filled in dataset order, but ``splits`` are expressed in the
+            # sampler's chunk order. ``inv`` maps a chunk-order position to its buffer position so
+            # the split semantics are independent of how chunks were regrouped across datasets.
+            inv = np.empty_like(order)
+            inv[order] = np.arange(order.size)
 
             raw_out: CSRContainer | np.ndarray = zsync.sync(self._index_datasets(dataset_index_to_rows))
 
@@ -801,12 +809,13 @@ class Loader[
             concatenated_obs: None | pd.DataFrame = self._maybe_accumulate_obs(dataset_index_to_rows)
             in_memory_indices: None | np.ndarray = self._maybe_accumulate_indices(dataset_index_to_rows)
             for split in splits:
-                data = in_memory_data[split]
+                sel = inv[split]
+                data = in_memory_data[sel]
                 yield {
                     "X": data if not self._to_torch else to_torch(data, self._preload_to_gpu),
-                    "obs": concatenated_obs.iloc[split] if concatenated_obs is not None else None,
+                    "obs": concatenated_obs.iloc[sel] if concatenated_obs is not None else None,
                     "var": self._var,
-                    "index": in_memory_indices[split] if in_memory_indices is not None else None,
+                    "index": in_memory_indices[sel] if in_memory_indices is not None else None,
                 }
 
             # https://github.com/cupy/cupy/issues/9625

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -795,7 +795,7 @@ class Loader[
             dataset_index_to_rows, order = self._slices_to_dataset_rows(chunks_to_load)
 
             # The buffer below is filled in dataset order, but ``splits`` are expressed in the
-            # sampler's chunk order. ``inv`` maps a chunk-order position to its buffer position so
+            # sampler's `LoadRequest.request` order. ``inv`` maps a request-order position to its buffer position so
             # the split semantics are independent of how chunks were regrouped across datasets.
             # ``order`` is a permutation of ``range(n)``, so every used slot is overwritten -- the
             # reused buffer never carries stale values from a previous request.

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -784,6 +784,11 @@ class Loader[
             ["Number of datasets", "Number of observations"],
         )
         is_sparse = issubclass(self.dataset_type, ad.abc.CSRDataset)
+        # ``inv`` (chunk-order position -> buffer position) and the identity ``positions`` are
+        # reused across requests: every window has the same size except possibly the last (smaller)
+        # one, so we allocate once and take truncated views, growing only if a window is ever larger.
+        inv_buffer = np.empty(0, dtype=np.intp)
+        positions = np.empty(0, dtype=np.intp)
         for load_request in self._batch_sampler.sample(self.n_obs):
             chunks_to_load = load_request["chunks"]
             splits = load_request["splits"]
@@ -792,8 +797,14 @@ class Loader[
             # The buffer below is filled in dataset order, but ``splits`` are expressed in the
             # sampler's chunk order. ``inv`` maps a chunk-order position to its buffer position so
             # the split semantics are independent of how chunks were regrouped across datasets.
-            inv = np.empty_like(order)
-            inv[order] = np.arange(order.size)
+            # ``order`` is a permutation of ``range(n)``, so every used slot is overwritten -- the
+            # reused buffer never carries stale values from a previous request.
+            n = order.size
+            if n > inv_buffer.size:
+                inv_buffer = np.empty(n, dtype=np.intp)
+                positions = np.arange(n, dtype=np.intp)
+            inv = inv_buffer[:n]
+            inv[order] = positions[:n]
 
             raw_out: CSRContainer | np.ndarray = zsync.sync(self._index_datasets(dataset_index_to_rows))
 

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -784,12 +784,9 @@ class Loader[
             ["Number of datasets", "Number of observations"],
         )
         is_sparse = issubclass(self.dataset_type, ad.abc.CSRDataset)
-        # ``inv`` (chunk-order position -> buffer position) and the identity ``positions`` are
-        # reused across requests: every window has the same size except possibly the last (smaller)
-        # one, so we allocate once and take truncated views, growing only if a window is ever larger.
-        inv_buffer = np.empty(0, dtype=np.intp)
+        # Create `positions` variable so we don't need to run `np.arange` (O(n)) every time
         positions = np.empty(0, dtype=np.intp)
-        for load_request in self._batch_sampler.sample(self.n_obs):
+for load_request in self._batch_sampler.sample(self.n_obs):
             chunks_to_load = load_request["chunks"]
             splits = load_request["splits"]
             dataset_index_to_rows, order = self._slices_to_dataset_rows(chunks_to_load)

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -800,11 +800,11 @@ class Loader[
             # ``order`` is a permutation of ``range(n)``, so every used slot is overwritten -- the
             # reused buffer never carries stale values from a previous request.
             n = order.size
-            if n > inv_buffer.size:
-                inv_buffer = np.empty(n, dtype=np.intp)
+            inv_buffer = np.empty(n, dtype=np.intp)
+            if n > positions.size:
                 positions = np.arange(n, dtype=np.intp)
             inv = inv_buffer[:n]
-            inv[order] = positions[:n]
+            inv = positions[order]
 
             raw_out: CSRContainer | np.ndarray = zsync.sync(self._index_datasets(dataset_index_to_rows))
 

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -786,7 +786,7 @@ class Loader[
         is_sparse = issubclass(self.dataset_type, ad.abc.CSRDataset)
         # Create `positions` variable so we don't need to run `np.arange` (O(n)) every time
         positions = np.empty(0, dtype=np.intp)
-for load_request in self._batch_sampler.sample(self.n_obs):
+        for load_request in self._batch_sampler.sample(self.n_obs):
             chunks_to_load = load_request["chunks"]
             splits = load_request["splits"]
             dataset_index_to_rows, order = self._slices_to_dataset_rows(chunks_to_load)

--- a/src/annbatch/types.py
+++ b/src/annbatch/types.py
@@ -27,22 +27,12 @@ class LoadRequest(TypedDict):
     chunks
         Chunks to load - a list of slices with a range of chunk_size except the last one which may be smaller but not empty.
     splits
-        How the in-memory data should be split into batches after it is read off disk.
+        How the in-memory data should be split into batches after it is read off disk and after all the chunks are loaded and concatenated in the order requested.
         A list of splits, last one may be partial but not empty i.e. 1 <= len(last_split) <= batch_size.
         If not provided, the sampler's batch_size property will be used to automatically generate splits.
 
     Notes
     -----
-    **Split index space**: ``splits`` index into the data in **chunk order** -- i.e. position ``j`` is
-    the ``j``-th observation when the chunks are concatenated in the order they appear in ``chunks``.
-    The sampler does not need to know how the loader lays out memory. Internally the loader fetches
-    chunks grouped by dataset index for efficiency (so the physical buffer is ordered by dataset, not
-    by chunk order), but it remaps each split back to chunk order before yielding, so this regrouping
-    is invisible to the sampler.
-
-    For example, given two datasets (dataset 0: rows 0-99, dataset 1: rows 100-199) and chunks
-    ``[slice(100, 110), slice(0, 10), slice(110, 120)]``, chunk-order position 0 is row 100, position
-    10 is row 0, position 20 is row 110 -- regardless of the dataset-grouped physical layout.
 
     .. warning::
         This is a **behaviour change in 0.2.0**. Before 0.2.0, ``splits`` had to index into the

--- a/src/annbatch/types.py
+++ b/src/annbatch/types.py
@@ -27,23 +27,29 @@ class LoadRequest(TypedDict):
     chunks
         Chunks to load - a list of slices with a range of chunk_size except the last one which may be smaller but not empty.
     splits
-        How the in-memory data should be split into batches after it is read off disk and concatenated in-memory.
+        How the in-memory data should be split into batches after it is read off disk.
         A list of splits, last one may be partial but not empty i.e. 1 <= len(last_split) <= batch_size.
         If not provided, the sampler's batch_size property will be used to automatically generate splits.
 
     Notes
     -----
-    **In-memory data ordering**: When chunks span multiple datasets, the loader groups and fetches
-    chunks by dataset index for efficiency. The resulting in-memory data is ordered by dataset index,
-    not by the original order of chunks in the `chunks` list. Within each dataset, chunks maintain
-    their relative order from the original list.
+    **Split index space**: ``splits`` index into the data in **chunk order** -- i.e. position ``j`` is
+    the ``j``-th observation when the chunks are concatenated in the order they appear in ``chunks``.
+    The sampler does not need to know how the loader lays out memory. Internally the loader fetches
+    chunks grouped by dataset index for efficiency (so the physical buffer is ordered by dataset, not
+    by chunk order), but it remaps each split back to chunk order before yielding, so this regrouping
+    is invisible to the sampler.
 
     For example, given two datasets (dataset 0: rows 0-99, dataset 1: rows 100-199) and chunks
-    ``[slice(100, 110), slice(0, 10), slice(110, 120)]``, the in-memory data will be ordered as:
-    ``[rows 0-10 from ds0, rows 100-110 from ds1, rows 110-120 from ds1]`` i.e., sorted by dataset index.
+    ``[slice(100, 110), slice(0, 10), slice(110, 120)]``, chunk-order position 0 is row 100, position
+    10 is row 0, position 20 is row 110 -- regardless of the dataset-grouped physical layout.
 
-    The `splits` indices must account for this ordering. For a single dataset, the in-memory order
-    naturally matches the chunk order since there's only one dataset to fetch from.
+    .. warning::
+        This is a **behaviour change in 0.2.0**. Before 0.2.0, ``splits`` had to index into the
+        loader's dataset-grouped physical layout (i.e. observations ordered by dataset index, not by
+        chunk order), so custom samplers had to account for that reordering themselves. They now index
+        in chunk order and the loader remaps them internally. Custom samplers written for earlier
+        versions that compensated for the dataset reordering must drop that compensation.
 
     """
 

--- a/src/annbatch/types.py
+++ b/src/annbatch/types.py
@@ -27,7 +27,7 @@ class LoadRequest(TypedDict):
     chunks
         Chunks to load - a list of slices with a range of chunk_size except the last one which may be smaller but not empty.
     splits
-        How the in-memory data should be split into batches after it is read off disk and after all the chunks are loaded and concatenated in the order requested.
+        How the in-memory data should be split into batches after it is read off disk and after all the chunks are loaded and concatenated in the order requested by `chunks`.
         A list of splits, last one may be partial but not empty i.e. 1 <= len(last_split) <= batch_size.
         If not provided, the sampler's batch_size property will be used to automatically generate splits.
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -752,8 +752,8 @@ def test_splits_are_chunk_order_across_datasets(adata_with_zarr_path_same_var_sp
 
     batches = list(loader)
     # split 0 -> chunk A -> dataset 1's first 10 rows ; split 1 -> chunk B -> dataset 0's first 10 rows
-    assert np.array_equal(batches[0]["index"], np.arange(n0, n0 + 10))
-    assert np.array_equal(batches[1]["index"], np.arange(0, 10))
+    assert np.array_equal(batches[0]["index"], np.arange(chunk_from_data1.start, chunk_from_data1.stop))
+    assert np.array_equal(batches[1]["index"], np.arange(chunk_from_data0.start, chunk_from_data0.stop))
     # data follows the index: each batch is exactly the requested chunk's rows read off disk
     np.testing.assert_array_equal(np.asarray(batches[0]["X"]), np.asarray(data1["dataset"][0:10]))
     np.testing.assert_array_equal(np.asarray(batches[1]["X"]), np.asarray(data0["dataset"][0:10]))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -738,13 +738,17 @@ def test_splits_are_chunk_order_across_datasets(adata_with_zarr_path_same_var_sp
     data0, data1 = open_dense(paths[0]), open_dense(paths[1])
     n0 = data0["dataset"].shape[0]  # dataset 0 -> global [0, n0) ; dataset 1 -> global [n0, ...)
 
-    # chunk A = dataset 1 rows [n0, n0 + 10); chunk B = dataset 0 rows [0, 10)  -> out of dataset order
+    chunk_from_data1 = slice(n0, n0 + 10)
+    chunk_from_data0 = slice(0, 10)
+    split_from_data1 = np.arange(0, 10)
+    split_from_data0 = np.arange(10, 20)
     sampler = _FixedRequestSampler(
         batch_size=10,
         preload_nchunks=2,
         chunk_size=10,
-        chunks=[slice(n0, n0 + 10), slice(0, 10)],
-        splits=[np.arange(0, 10), np.arange(10, 20)],  # split 0 = chunk A, split 1 = chunk B (chunk order)
+        # split 0 from data1, split 1 from data0
+        chunks=[chunk_from_data1, chunk_from_data0],
+        splits=[split_from_data1, split_from_data0],
     )
     loader = Loader(batch_sampler=sampler, return_index=True, preload_to_gpu=False, to_torch=False)
     loader.add_dataset(**data0)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -712,3 +712,48 @@ def test_warn_concat_strategy(concat_strategy: Literal["concat-shuffle", "shuffl
             rng=np.random.default_rng(0),
             concat_strategy=concat_strategy,
         )
+
+
+class _FixedRequestSampler(SequentialSampler):
+    """Emits one preselected LoadRequest with chunk-order splits, reusing SequentialSampler's plumbing."""
+
+    def __init__(self, chunks: list[slice], splits: list[np.ndarray], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._chunks, self._splits = chunks, splits
+
+    def _sample(self, n_obs: int):
+        yield {"chunks": self._chunks, "splits": self._splits}
+
+
+def test_splits_are_chunk_order_across_datasets(adata_with_zarr_path_same_var_space: tuple[ad.AnnData, Path]):
+    """Splits index in chunk order; the loader undoes its dataset-grouped buffer layout.
+
+    The request lists a chunk from dataset 1 *before* a chunk from dataset 0, so the loader's
+    in-memory buffer (grouped by dataset) is the reverse of chunk order. Each split selects one
+    chunk's positions, so each batch must be exactly that chunk's rows. Before the chunk-order
+    remap, the dataset-grouped buffer leaked the wrong rows into each batch -- this test would
+    have failed.
+    """
+    paths = sorted(adata_with_zarr_path_same_var_space[1].glob("*.zarr"))
+    data0, data1 = open_dense(paths[0]), open_dense(paths[1])
+    n0 = data0["dataset"].shape[0]  # dataset 0 -> global [0, n0) ; dataset 1 -> global [n0, ...)
+
+    # chunk A = dataset 1 rows [n0, n0 + 10); chunk B = dataset 0 rows [0, 10)  -> out of dataset order
+    sampler = _FixedRequestSampler(
+        batch_size=10,
+        preload_nchunks=2,
+        chunk_size=10,
+        chunks=[slice(n0, n0 + 10), slice(0, 10)],
+        splits=[np.arange(0, 10), np.arange(10, 20)],  # split 0 = chunk A, split 1 = chunk B (chunk order)
+    )
+    loader = Loader(batch_sampler=sampler, return_index=True, preload_to_gpu=False, to_torch=False)
+    loader.add_dataset(**data0)
+    loader.add_dataset(**data1)
+
+    batches = list(loader)
+    # split 0 -> chunk A -> dataset 1's first 10 rows ; split 1 -> chunk B -> dataset 0's first 10 rows
+    assert np.array_equal(batches[0]["index"], np.arange(n0, n0 + 10))
+    assert np.array_equal(batches[1]["index"], np.arange(0, 10))
+    # data follows the index: each batch is exactly the requested chunk's rows read off disk
+    np.testing.assert_array_equal(np.asarray(batches[0]["X"]), np.asarray(data1["dataset"][0:10]))
+    np.testing.assert_array_equal(np.asarray(batches[1]["X"]), np.asarray(data0["dataset"][0:10]))


### PR DESCRIPTION
hi,

this PR at first had a performance improvement that's not much related to the behaviour change. We now do the per dataset ordering with `np.searchsorted` and here are it's results (complexity is now `O(Nlog N + Nlog D)` instead of `O(DN)` N=loaded window, D=dataset num ). 

```
❯ python benchmarks/bench_slices_to_dataset_rows.py
       N      D  touched   old (ms)   new (ms)  speedup
   16384     10        8      0.105      0.431     0.2x
   16384    100       32      0.746      0.756     1.0x
   16384   1000       32      6.148      0.934     6.6x
   16384  10000       32     60.798      1.192    51.0x
  131072   1000       64     37.551      7.739     4.9x
 1048576   1000       32    299.981     57.358     5.2x
```

as a side effect this refactored `_slices_to_dataset_rows` now creates `orders` variable which we can use to rectify the split's in a way so that now at the sampler level the order of given splits would be applied to the chunks in only on the chunk order from the LoadRequest. This is the breaking change. We used to need to account for the layout of the datasets when yielding splits from samplers but the Loader now accounts for that. This will also unblock the categorical sampler PR, because pure batches won't be a problem. 

I also added unit tests which would fail before the changes here but now ensure splits are applied to the requested chunks in order.
