### PR TITLE
ci: bump codecov-action to v6 to fix signature verification

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -88,7 +88,7 @@ jobs:
           uv run coverage combine
           uv run coverage xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
           uvx hatch run ${{ matrix.env.name }}:cov-report   # report visibly
           uvx hatch run ${{ matrix.env.name }}:coverage xml # create report for upload
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
`codecov-action@v5` verifies the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating accounts. Uploads now fail with `Could not verify signature`. `@v6` (= 6.0.2) ships the updated key. Version pin bump.

Ref: https://github.com/codecov/codecov-action/issues/1956