### PR TITLE
perf: don't apply fancy indexing if split can be a slice.

### DIFF
--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -1000,7 +1000,7 @@ class Loader[
                 sel = inv[split]
 
                 # Use basic slicing for contiguous selections to avoid costly fancy indexing on the loaded memory
-                if len(sel) > 0 and ((sel[-1] - sel[0] == len(sel) - 1 and  np.all(np.diff(sel) == 1))):
+                if len(sel) > 0 and (sel[-1] - sel[0] == len(sel) - 1 and np.all(np.diff(sel) == 1)):
                     sel = slice(sel[0], sel[-1] + 1)
 
                 data = in_memory_data[sel]

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -998,7 +998,9 @@ class Loader[
             in_memory_indices: None | np.ndarray = self._maybe_accumulate_indices(dataset_index_to_rows)
             for split in splits:
                 sel = inv[split]
-                if len(sel) > 0 and np.all(np.diff(sel) == 1):
+
+                # Use basic slicing for contiguous selections to avoid costly fancy indexing on the loaded memory
+                if len(sel) > 0 and ((sel[-1] - sel[0] == len(sel) - 1 and  np.all(np.diff(sel) == 1))):
                     sel = slice(sel[0], sel[-1] + 1)
 
                 data = in_memory_data[sel]

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -998,6 +998,9 @@ class Loader[
             in_memory_indices: None | np.ndarray = self._maybe_accumulate_indices(dataset_index_to_rows)
             for split in splits:
                 sel = inv[split]
+                if len(sel) > 0 and np.all(np.diff(sel) == 1):
+                    sel = slice(sel[0], sel[-1] + 1)
+
                 data = in_memory_data[sel]
                 yield {
                     "X": data if not self._to_torch else to_torch(data, self._preload_to_gpu),


### PR DESCRIPTION
In my use case when batch_size=1, splits becomes something like this = [[0],[1],[2],...]. For each split I think this becomes a fancy indexing operation and can be costly. In my case every row is 40mb. And I want to have some preloaded rows but turns out each in_memory_data[split] is costly even though it fetches for one row. 

This is a bit more of a generalized case. But I added `(split[-1] - split[0] == len(split) - 1` check so it returns early but if you think we should avoid this check we can also just have a special case for `batch_size=1`