### PR TITLE
Perf: buffer to avoid expensive fancy indexing for dense data

### DIFF
--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -996,7 +996,7 @@ class Loader[
                 raw_out_arr = self._np_module.asarray(raw_out)
                 needed_len = len(concat_splits)
                 feature_shape = raw_out_arr.shape[1:]
-                if self._dense_split_buffer is None:
+                if self._dense_split_buffer is None or self._dense_split_buffer.dtype != raw_out_arr.dtype:
                     self._dense_split_buffer = self._np_module.empty(
                         (needed_len, *feature_shape),
                         raw_out_arr.dtype,

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -995,7 +995,6 @@ class Loader[
                     shape=raw_out.shape,
                     dtype=_cupy_dtype(raw_out.dtype) if self._preload_to_gpu else raw_out.dtype,
                 )
-                in_memory_data = in_memory_data[sel]
             else:
                 raw_out_arr = self._np_module.asarray(raw_out)
                 needed_len = len(concat_splits)
@@ -1026,7 +1025,8 @@ class Loader[
             start = 0
             for split in splits:
                 end = start + len(split)
-                data = in_memory_data[start:end]
+                # if data is sparse splits isn't applied to it yet
+                data = in_memory_data[sel] if is_sparse else in_memory_data[slice(start, end)] 
                 yield {
                     "X": data if not self._to_torch else to_torch(data, self._preload_to_gpu),
                     "obs": concatenated_obs.iloc[start:end] if concatenated_obs is not None else None,

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -997,10 +997,9 @@ class Loader[
                 needed_len = len(concat_splits)
                 feature_shape = raw_out_arr.shape[1:]
                 if self._dense_split_buffer is None:
-                    self._dense_split_buffer = self._alloc(
+                    self._dense_split_buffer = self._np_module.empty(
                         (needed_len, *feature_shape),
                         raw_out_arr.dtype,
-                        use_pinned=self._preload_to_gpu,
                     )
                 in_memory_data = self._dense_split_buffer[:needed_len]
                 self._np_module.take(

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -982,8 +982,7 @@ class Loader[
             inv = inv_buffer[:n]
             inv[order] = positions[:n]
             concat_splits = np.concatenate(splits)
-            sel = inv[concat_splits] # same as inv = positions[order] but reuses preallocated buffer
-
+            sel = inv[concat_splits]  # same as inv = positions[order] but reuses preallocated buffer
 
             raw_out: CSRContainer | np.ndarray = zsync.sync(self._index_datasets(dataset_index_to_rows))
 
@@ -1009,7 +1008,7 @@ class Loader[
                     sel,
                     axis=0,
                     out=in_memory_data,
-                    **({"mode": "clip"} if not self._preload_to_gpu else {}), # cp.take doesn't have mode kwarg
+                    **({"mode": "clip"} if not self._preload_to_gpu else {}),  # cp.take doesn't have mode kwarg
                 )
 
             concatenated_obs: None | pd.DataFrame = self._maybe_accumulate_obs(dataset_index_to_rows)
@@ -1024,7 +1023,7 @@ class Loader[
             for split in splits:
                 end = start + len(split)
                 # if data is sparse splits isn't applied to it yet
-                data = in_memory_data[sel] if is_sparse else in_memory_data[slice(start, end)] 
+                data = in_memory_data[sel] if is_sparse else in_memory_data[slice(start, end)]
                 yield {
                     "X": data if not self._to_torch else to_torch(data, self._preload_to_gpu),
                     "obs": concatenated_obs.iloc[start:end] if concatenated_obs is not None else None,

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -1023,7 +1023,7 @@ class Loader[
             for split in splits:
                 end = start + len(split)
                 # if data is sparse splits isn't applied to it yet
-                data = in_memory_data[sel] if is_sparse else in_memory_data[slice(start, end)]
+                data = in_memory_data[inv[split]] if is_sparse else in_memory_data[slice(start, end)]
                 yield {
                     "X": data if not self._to_torch else to_torch(data, self._preload_to_gpu),
                     "obs": concatenated_obs.iloc[start:end] if concatenated_obs is not None else None,

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -233,6 +233,7 @@ class Loader[
         self._train_datasets = []
         self._shapes = []
         self._sparse_dataset_elem_cache = {}
+        self._dense_split_buffer = None
 
     def __len__(self) -> int:
         return self._batch_sampler.n_batches(self.n_obs)
@@ -981,7 +982,10 @@ class Loader[
             if n > positions.size:
                 positions = np.arange(n, dtype=np.intp)
             inv = inv_buffer[:n]
-            inv = positions[order]
+            inv[order] = positions[:n]
+            concat_splits = np.concatenate(splits)
+            sel = inv[concat_splits] # same as inv = positions[order] but reuses preallocated buffer
+
 
             raw_out: CSRContainer | np.ndarray = zsync.sync(self._index_datasets(dataset_index_to_rows))
 
@@ -991,20 +995,45 @@ class Loader[
                     shape=raw_out.shape,
                     dtype=_cupy_dtype(raw_out.dtype) if self._preload_to_gpu else raw_out.dtype,
                 )
+                in_memory_data = in_memory_data[sel]
             else:
-                in_memory_data = self._np_module.asarray(raw_out)
+                raw_out_arr = self._np_module.asarray(raw_out)
+                needed_len = len(concat_splits)
+                feature_shape = raw_out_arr.shape[1:]
+                if self._dense_split_buffer is None:
+                    self._dense_split_buffer = self._alloc(
+                        (needed_len, *feature_shape),
+                        raw_out_arr.dtype,
+                        use_pinned=self._preload_to_gpu,
+                    )
+                in_memory_data = self._dense_split_buffer[:needed_len]
+                self._np_module.take(
+                    raw_out_arr,
+                    sel,
+                    axis=0,
+                    out=in_memory_data,
+                    **({"mode": "clip"} if not self._preload_to_gpu else {}), # cp.take doesn't have mode kwarg
+                )
 
             concatenated_obs: None | pd.DataFrame = self._maybe_accumulate_obs(dataset_index_to_rows)
+            if concatenated_obs is not None:
+                concatenated_obs = concatenated_obs.iloc[sel]
+
             in_memory_indices: None | np.ndarray = self._maybe_accumulate_indices(dataset_index_to_rows)
+            if in_memory_indices is not None:
+                in_memory_indices = in_memory_indices[sel]
+
+            start = 0
             for split in splits:
-                sel = inv[split]
-                data = in_memory_data[sel]
+                end = start + len(split)
+                data = in_memory_data[start:end]
                 yield {
                     "X": data if not self._to_torch else to_torch(data, self._preload_to_gpu),
-                    "obs": concatenated_obs.iloc[sel] if concatenated_obs is not None else None,
+                    "obs": concatenated_obs.iloc[start:end] if concatenated_obs is not None else None,
                     "var": self._var,
-                    "index": in_memory_indices[sel] if in_memory_indices is not None else None,
+                    "index": in_memory_indices[start:end] if in_memory_indices is not None else None,
                 }
+                start = end
 
             # https://github.com/cupy/cupy/issues/9625
             if self._preload_to_gpu and is_sparse:

--- a/src/annbatch/loader.py
+++ b/src/annbatch/loader.py
@@ -1022,7 +1022,7 @@ class Loader[
             for split in splits:
                 end = start + len(split)
                 # if data is sparse splits isn't applied to it yet
-                data = in_memory_data[inv[split]] if is_sparse else in_memory_data[slice(start, end)]
+                data = in_memory_data[inv[split]] if is_sparse else in_memory_data[slice(start, end)].copy()
                 yield {
                     "X": data if not self._to_torch else to_torch(data, self._preload_to_gpu),
                     "obs": concatenated_obs.iloc[start:end] if concatenated_obs is not None else None,


### PR DESCRIPTION
For the case of dense data (like in genomic data) and when the feature size is big. I noticed that when bs=1, cs=1, and preload_nchunks=120, lot's of time is being spent on in_memory_data[split] because creates a copy of the row instead of just selecting that row as a view. We can have inplace indexing if we have a buffer using np.take(out=buffer). Would also solve https://github.com/scverse/annbatch/pull/235

I will give real life data once I run this branch